### PR TITLE
Add a method of decrypting that can be used when packets are missing

### DIFF
--- a/crackle.h
+++ b/crackle.h
@@ -55,6 +55,8 @@ struct _crackle_state_t {
     pcap_dumper_t *dumper;
     int total_processed;
     int total_decrypted;
+    pcap_t *cap;
+    int test_decrypt;
 
     uint64_t packet_counter[2]; // 0: master, 1: slave
 };


### PR DESCRIPTION
I added a way to find the LTK that only requires the LL_ENC_REQ, LL_ENC_RSP and the two random packets. 

It takes significantly longer than the previous method, which is why I placed it behind the `-s` flag. It takes about 10 minutes to brute force all of the million options for the TK on my laptop. 

It is based on my other two pull requests as well. Especially the general improvements one is needed, since the memory leak really causes issues with this approach. And the `-O2` change is also pretty nice, since that makes it quite a bit faster.