### PR TITLE
Add multithreading with OpenMP for STK brute forcing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INSTALL_DIR ?= $(DESTDIR)/$(PREFIX)/bin
 
 OBJS = crackle.o aes.o aes-ccm.o aes-enc.o test.o
 
-CFLAGS  ?= -O2 -Wall -Werror -g
+CFLAGS  ?= -O2 -Wall -Werror -g -Wno-unknown-pragmas -fopenmp
 LDFLAGS ?=
 
 all: crackle


### PR DESCRIPTION
Use OpenMP to add multithreading to the STK brute force loop. On my laptop (dualcore i5 with hyperthreading) it had a speedup of about 1.5.