### PR TITLE
Only check for access address when CONNECT_REQ was found

### DIFF
--- a/crackle.c
+++ b/crackle.c
@@ -260,7 +260,7 @@ static void packet_decrypter(crackle_state_t *state,
 
     aa = read_32(btle_bytes);
 
-    if (aa != state->aa)
+    if (state->connect_found && aa != state->aa)
         goto out;
 
     uint8_t flags = read_8(btle_bytes + 4);


### PR DESCRIPTION
In LTK mode and STK brute force mode the CONNECT_REQ packet is optional. But when it is not available it will skip the data packets when decrypting.