### PR TITLE
Follow Bluetooth specification 4.0 and fix issues

### DIFF
--- a/crackle.c
+++ b/crackle.c
@@ -611,7 +611,6 @@ int main(int argc, char **argv) {
     int opt;
     int verbose = 0, do_tests = 0;
     int do_tk_crack = 1, do_stk_crack = 0, do_ltk_decrypt = 0;
-    int do_reverse = 0;
     char *pcap_file = NULL;
     char *pcap_file_out = NULL;
     char *ltk = NULL;
@@ -644,10 +643,6 @@ int main(int argc, char **argv) {
                 do_tk_crack = 0;
                 do_ltk_decrypt = 1;
                 ltk = strdup(optarg);
-                break;
-
-            case 'r':
-                do_reverse = 1;
                 break;
 
             case 'h':
@@ -762,27 +757,14 @@ int main(int argc, char **argv) {
 
     if (do_tk_crack) {
         // brute force the TK, starting with 0 for Just Works
-        if (do_reverse) {
-            for (numeric_key = 999999; numeric_key >= 0; --numeric_key) {
-                calc_confirm(&state, 1, numeric_key, confirm_mrand);
-                calc_confirm(&state, 0, numeric_key, confirm_srand);
-                r1 = memcmp(state.mconfirm, confirm_mrand, 16);
-                r2 = memcmp(state.mconfirm, confirm_srand, 16);
-                if (r1 == 0 || r2 == 0) {
-                    tk_found = 1;
-                    break;
-                }
-            }
-        } else {
-            for (numeric_key = 0; numeric_key <= 999999; numeric_key++) {
-                calc_confirm(&state, 1, numeric_key, confirm_mrand);
-                calc_confirm(&state, 0, numeric_key, confirm_srand);
-                r1 = memcmp(state.mconfirm, confirm_mrand, 16);
-                r2 = memcmp(state.mconfirm, confirm_srand, 16);
-                if (r1 == 0 || r2 == 0) {
-                    tk_found = 1;
-                    break;
-                }
+        for (numeric_key = 0; numeric_key <= 999999; numeric_key++) {
+            calc_confirm(&state, 1, numeric_key, confirm_mrand);
+            calc_confirm(&state, 0, numeric_key, confirm_srand);
+            r1 = memcmp(state.mconfirm, confirm_mrand, 16);
+            r2 = memcmp(state.mconfirm, confirm_srand, 16);
+            if (r1 == 0 || r2 == 0) {
+                tk_found = 1;
+                break;
             }
         }
 

--- a/crackle.c
+++ b/crackle.c
@@ -351,7 +351,7 @@ static void packet_decrypter(crackle_state_t *state,
             else
                 pcap_breakloop(state->cap);
 
-            goto out;
+            goto done;
         }
     }
     else {

--- a/crackle.c
+++ b/crackle.c
@@ -358,7 +358,7 @@ static void packet_decrypter(crackle_state_t *state,
         // LL Control PDU
         if ((flags & 3) == 3) {
             uint8_t opcode = read_8(btle_bytes + 6);
-            if (opcode == 0x4) // LL_ENC_RSP
+            if (opcode == 0x5) // LL_START_ENC_REQ
                 state->decryption_active = 1;
         }
     }

--- a/crackle.c
+++ b/crackle.c
@@ -278,7 +278,7 @@ static void packet_decrypter(crackle_state_t *state,
         if (len > 0) {
             int r, i, j;
             uint8_t out[64];
-            uint8_t adata[16] = { flags & 0xf3, 0x00, };
+            uint8_t adata[16] = { flags & 0xe3, 0x00, };
             uint8_t nonce[16];
             const uint8_t *mic;
 

--- a/crackle.c
+++ b/crackle.c
@@ -618,6 +618,7 @@ int main(int argc, char **argv) {
     char errbuf[PCAP_ERRBUF_SIZE];
     pcap_t *cap;
     pcap_handler packet_handler;
+    int cap_dlt;
     crackle_state_t state;
     crackle_state_t dup_state;
     int err_count = 0;
@@ -730,7 +731,7 @@ int main(int argc, char **argv) {
     if (cap == NULL)
         errx(1, "%s", errbuf);
 
-    int cap_dlt = pcap_datalink(cap);
+    cap_dlt = pcap_datalink(cap);
 
     if(verbose)
         printf("PCAP contains [%s] frames\n", pcap_datalink_val_to_name(cap_dlt));
@@ -884,7 +885,7 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    pcap_t *pcap_dumpfile = pcap_open_dead(DLT_PPI, 128);
+    pcap_t *pcap_dumpfile = pcap_open_dead(cap_dlt, 128);
     if (pcap_dumpfile == NULL)
         err(1, "pcap_open_dead: ");
     state.dumper = pcap_dump_open(pcap_dumpfile, pcap_file_out);


### PR DESCRIPTION
When I tested crackle with my smartwatch, I noticed that some packets got not decrypted (even if they were encryped). So I started to read the Bluetooth spec 4.0 and discovered two errors that are fixed by the commits below. I also add the patch from JelteF about copying non-decrypted packet.