### PR TITLE
must create directory before installing a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ crackle: $(OBJS)
 	$(CC) $(CFLAGS) -o crackle $(OBJS) -lpcap $(LDFLAGS)
 
 install: crackle
+	$(INSTALL) -d $(INSTALL_DIR)
 	$(INSTALL) -m 0755 crackle $(INSTALL_DIR)
 
 uninstall:


### PR DESCRIPTION
package managers install files into a temp directory then merge onto the live filesystem so dirs like /usr/bin don't exist and must be created