### PR TITLE
support decrypting of capture file using nordic Bluetooth sniffer

### DIFF
--- a/crackle.h
+++ b/crackle.h
@@ -78,6 +78,7 @@ struct _connection_state_t {
 
 struct _crackle_state_t {
     btle_handler_t btle_handler;
+    btle_handler_t decrypted_handler;
 
     unsigned pcap_idx;
 


### PR DESCRIPTION
Support decrypting of capture files when using the nRF Sniffer for
Bluetooth LE.
If the are received including the MIC field and successfully decrypted
the length field must be updated to exclude the MIC field.
Mark the MIC as valid when decrypted.

Also updates the sniffer meta definition to the one that is currently in use.