### PR TITLE
Modify Nordic sniffer payload length after decrypt

### DIFF
--- a/crackle.h
+++ b/crackle.h
@@ -15,6 +15,12 @@ typedef void (*btle_handler_t)(crackle_state_t *state,
                                off_t offset,
                                size_t len);
 
+// header update hook for different formats if their header data needs to be
+// changed after packet decryption
+typedef void (*format_header_updater_t)(const crackle_state_t *state,
+                               const struct pcap_pkthdr *h,
+                               u_char *packet_bytes);
+
 struct _encrypted_packet_t {
     unsigned pcap_idx;
 
@@ -78,6 +84,7 @@ struct _connection_state_t {
 
 struct _crackle_state_t {
     btle_handler_t btle_handler;
+    format_header_updater_t format_header_updater;
 
     unsigned pcap_idx;
 


### PR DESCRIPTION
Hello,

this fixes an issue where Wireshark cannot parse packets in the Nordic BLE format when the payload length in the header is not set correctly. This adds a function hook to modify packet headers right before writing them to the output file and uses it to correctly set the payload length in the Nordic header.

The only (unofficial?) documentation of the protocol that Nordic sniffers use I could find is https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-nordic_ble.c. However, this does not specify how to actually detect the protocol legacy version 0; if you know how to do that, feel free to add support for it 😄 

Cheers,
bitcubik